### PR TITLE
feat(devTools): Improve process management and GitHub integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,12 @@ build/**
 !node_modules
 nix_system
 .direnv
+attached_assets/
 static/build
 .cache
 .local
 node_modules
 vendor
-.git
 .config
 .git
+.sl

--- a/infra/bff/friends/devTools.bff.ts
+++ b/infra/bff/friends/devTools.bff.ts
@@ -1,0 +1,89 @@
+import { register } from "infra/bff/bff.ts";
+import { runShellCommand, runningProcesses } from "infra/bff/shellBase.ts";
+import { getLogger } from "packages/logger.ts";
+
+const logger = getLogger(import.meta);
+
+// Install a SIGINT signal listener to terminate child processes on Ctrl+C
+Deno.addSignalListener("SIGINT", () => {
+  console.log("Ctrl+C pressed. Terminating child processes...");
+  for (const proc of runningProcesses) {
+    // Send SIGTERM (or you can choose another signal)
+    proc.kill("SIGTERM");
+  }
+  // Optionally exit after a short delay to allow cleanup
+  Deno.exit();
+});
+
+// Register both command names
+["devTool", "devTools"].forEach((commandName) => {
+  register(
+    commandName,
+    "Run development tools (Sapling web and Jupyter notebook)",
+    async () => {
+      console.log("Starting Jupyter and Sapling web interface...");
+
+      // Kill any existing Jupyter processes
+      try {
+        await runShellCommand([
+          "pkill",
+          "-f",
+          "jupyter-notebook",
+        ], undefined, {}, false);
+        
+        await runShellCommand([
+          "sl",
+          "web",
+          "--kill",
+        ], undefined, {}, false);
+      } catch (e) {
+        // Ignore errors if no processes were found
+      }
+
+      // Start both processes in parallel
+      const port = Deno.env.get("REPLIT_PID2") === "true" ? "8284" : "8283";
+      const session = Deno.env.get("REPLIT_SESSION");
+      
+      // Get GitHub token from extension API
+      const tokenResponse = await fetch(`http://localhost:${port}/${session}/github/token`);
+      const tokenData = await tokenResponse.json();
+      const token = tokenData.token || "";
+      
+      // Set environment for child processes
+      const env = { ...Deno.env.toObject(), GH_TOKEN: token };
+
+      try {
+        const promises = [
+          // Start Sapling web interface
+          runShellCommand([
+            "sl",
+            "web",
+            "-f",
+            "--no-open",
+          ], undefined, env, false),
+
+          // Start Jupyter notebook
+          runShellCommand([
+            "deno",
+            "jupyter",
+            "--install",
+          ], undefined, env, false).then(() =>
+            runShellCommand([
+              "jupyter",
+              "notebook",
+              "--config",
+              "./infra/jupyter/config.py",
+            ], undefined, env, false)
+          ),
+        ];
+
+        await Promise.all(promises);
+        console.log("Go to 'Extension Devtools' to use the dev tools.");
+        return 0;
+      } catch (error) {
+        logger.error("Failed to start development tools:", error);
+        return 1;
+      }
+    },
+  );
+});

--- a/infra/bff/friends/land.bff.ts
+++ b/infra/bff/friends/land.bff.ts
@@ -1,0 +1,121 @@
+import { register } from "infra/bff/bff.ts";
+import { runShellCommand, runShellCommandWithOutput } from "infra/bff/shellBase.ts";
+import { getLogger } from "packages/logger.ts";
+
+const logger = getLogger(import.meta);
+
+async function getSaplingCommitsSince(lastSaplingHash: string): Promise<Array<string>> {
+  const output = await runShellCommandWithOutput([
+    "sl",
+    "log",
+    `-r"${lastSaplingHash}::."`,
+    "--template",
+    "{desc}\n",
+  ]);
+  return output.split("\n").filter(Boolean);
+}
+
+async function getCurrentSaplingHash(): Promise<string> {
+  return (await runShellCommandWithOutput([
+    "sl",
+    "log",
+    "-r",
+    ".",
+    "--template",
+    "{node}",
+  ])).trim();
+}
+
+async function getLastSaplingHashFromGit(): Promise<string | null> {
+  try {
+    const lastCommitMsg = await runShellCommandWithOutput([
+      "git",
+      "log",
+      "-1",
+      "--pretty=%B",
+    ]);
+    const match = lastCommitMsg.match(/Sapling-Hash: ([a-f0-9]+)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+register(
+  "land",
+  "Pull code from sapling, install deps, and create a git commit",
+  async () => {
+    // First pull the latest code
+    logger.info("Pulling latest code from sapling...");
+    const pullResult = await runShellCommand([
+      "sl",
+      "pull",
+    ]);
+
+    if (pullResult !== 0) {
+      logger.error("Failed to pull latest code");
+      return pullResult;
+    }
+
+    // Install dependencies
+    logger.info("Installing dependencies...");
+    const installResult = await runShellCommand([
+      "deno",
+      "install",
+    ]);
+
+    if (installResult !== 0) {
+      logger.error("Failed to install dependencies");
+      return installResult;
+    }
+
+    const currentSaplingHash = await getCurrentSaplingHash();
+    const lastSaplingHash = await getLastSaplingHashFromGit();
+
+    let commitMsg = "";
+    if (lastSaplingHash) {
+      const commits = await getSaplingCommitsSince(lastSaplingHash);
+      commitMsg = commits.join("\n\n");
+    } else {
+      commitMsg = await runShellCommandWithOutput([
+        "sl",
+        "log",
+        "-r",
+        ".",
+        "--template",
+        "{desc}",
+      ]);
+    }
+
+    // Add all changes to git
+    logger.info("Adding changes to git...");
+    const addResult = await runShellCommand([
+      "git",
+      "add",
+      ".",
+    ]);
+
+    if (addResult !== 0) {
+      logger.error("Failed to add changes to git");
+      return addResult;
+    }
+
+    // Create git commit with sapling commits and hash
+    logger.info("Creating git commit...");
+    const fullCommitMsg = `${commitMsg.trim()}\n\nSapling-Hash: ${currentSaplingHash}`;
+    const commitResult = await runShellCommand([
+      "git",
+      "commit",
+      "-m",
+      fullCommitMsg,
+    ]);
+
+    if (commitResult !== 0) {
+      logger.error("Failed to create git commit");
+      return commitResult;
+    }
+
+    logger.info("Successfully landed changes!");
+    return 0;
+  },
+);

--- a/infra/bff/friends/pull.bff.ts
+++ b/infra/bff/friends/pull.bff.ts
@@ -1,0 +1,18 @@
+
+import { register } from "infra/bff/bff.ts";
+import { runShellCommand } from "infra/bff/shellBase.ts";
+import { getLogger } from "packages/logger.ts";
+
+const logger = getLogger(import.meta);
+
+register(
+  "pull",
+  "Pull the latest code from sapling",
+  async () => {
+    logger.info("Pulling latest code from sapling...");
+    return await runShellCommand([
+      "sl",
+      "pull",
+    ]);
+  },
+);

--- a/infra/jupyter/config.py
+++ b/infra/jupyter/config.py
@@ -3,21 +3,19 @@ import os
 c.ServerApp.ip = '0.0.0.0'
 c.ServerApp.allow_origin = '*'
 c.ServerApp.open_browser = False
-c.ServerApp.token = 'bfjupyter'  # This will be the URL token
-c.ServerApp.password = ''  # Disable password prompt when token is used
+c.ServerApp.token = 'bfjupyter'
+c.ServerApp.password = ''
+c.ServerApp.allow_remote_access = True
+c.ServerApp.terminado_settings = {'shell_command': ['/bin/bash']}
 c.ServerApp.tornado_settings = {
     'headers': {
         'Content-Security-Policy': "frame-ancestors 'self' https://replit.com"
     }
 }
 
-path = "."
-c.ServerApp.root_dir = path
-
-# Use a fixed token for authentication
-c.ServerApp.password = ""
-c.ServerApp.password_required = False
-
-# Optional: Fixed port and no retries
+c.ServerApp.root_dir = "."
 c.ServerApp.port = 8888
 c.ServerApp.port_retries = 0
+
+c.ServerApp.shutdown_no_confirm = True
+c.MappingKernelManager.default_kernel_name = 'deno'


### PR DESCRIPTION
- Add Jupyter process cleanup before startup to prevent port conflicts
- Add Sapling process cleanup using `sl kill` before startup
- Add GitHub token integration for Sapling process environment
- Fix process environment configuration to ensure GH_TOKEN is properly exposed

Technical details:
- Kill any running Jupyter processes on port 8888
- Run `sl kill` before starting new Sapling instance
- Pass GitHub token through process environment instead of sl config
- Clean up environment variable handling in devTools.bff.ts

Testing steps:
1. First, start the dev tools: `bff devTools`

2. Check if Jupyter is running by:
- Opening your browser to port 8888
- Verifying you see the Jupyter interface
- Creating a new notebook to confirm it works

3. Test the cleanup by:
- Running `bff devTools` again
- Verifying you can still access Jupyter without port conflicts
- The old process should be killed automatically

4. Test Sapling by:
- Checking if you can access the Sapling web interface
- Making some changes and verifying Sapling shows them
- Running `bff devTools` again to verify Sapling restarts cleanly

5. Test GitHub integration by:
- Making some changes in Sapling
- Verifying the GitHub token is working by trying to commit
- The commit should work without auth errors
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/content-foundry/content-foundry/pull/49).
* #50
* __->__ #49

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/content-foundry/content-foundry/49)
<!-- GitContextEnd -->