### PR TITLE
Add instructions for GitHub authentication in development workflow

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -138,6 +138,8 @@ advanced features while maintaining compatibility with Git.
 - `sl push` - Push changes to remote
 - `sl pull` - Pull changes from remote
 - `sl goto` - Switch to specific branch or commit
+- `sl goto prXXX` - Switch to a specific pull request branch (e.g.,
+  `sl goto pr316`)
 - `sl log` - View commit history
 - `sl web` - Start Sapling web interface
 - `sl diff` - Show changes in working directory
@@ -581,9 +583,24 @@ The database abstraction makes it easy to add new backend implementations:
 
 To get started with Content Foundry development:
 
-1. Start the development environment: `bff devTools`
+1. Authenticate with GitHub using the GitHub CLI:
+   ```bash
+   gh auth login
+   ```
+   - This will start an interactive authentication process
+   - You'll be prompted to choose how you want to authenticate (web browser,
+     token, etc.)
+   - This authentication is required for PR operations and other GitHub
+     integrations
+
+2. Start the development environment: `bff devTools`
    - This will help you get logged in and set up your environment
-2. Access development tools:
+   - If you're not authenticated with GitHub, this command will also help you
+     log in
+   - It will display a GitHub device code that you can copy and use to complete
+     authentication
+
+3. Access development tools:
    - Web app: http://localhost:8000
    - Sapling web: http://localhost:3011
    - Jupyter: http://localhost:8888


### PR DESCRIPTION

## Summary
- Added detailed GitHub CLI authentication instructions to the Getting Started section
- Added instructions for how to use the GitHub device code for authentication
- Added documentation for using `sl goto pr<number>` command
- Improved the step numbering for the development workflow section

## Test Plan
- Verified documentation is correctly formatted
- Confirmed all steps are clearly explained
- Ensured proper Markdown rendering of code blocks
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/content-foundry/content-foundry/pull/319).
* #320
* #316
* __->__ #319