### PR TITLE
Improve logger calls by removing JSON.stringify

### DIFF
--- a/packages/bfDb/bfDb.ts
+++ b/packages/bfDb/bfDb.ts
@@ -257,15 +257,12 @@ export async function bfQueryItemsUnified<
 
   logger.debug(`Standard query returned ${results.length} results`);
   if (results.length === 0) {
-    logger.debug(`No results found. Query parameters: 
-      metadataToQuery: ${JSON.stringify(metadataToQuery)}
-      propsToQuery: ${JSON.stringify(propsToQuery)}
-      bfGids: ${bfGids ? JSON.stringify(bfGids) : "undefined"}
-    `);
+    logger.debug("No results found. Query parameters:");
+    logger.debug("metadataToQuery:", metadataToQuery);
+    logger.debug("propsToQuery:", propsToQuery);
+    logger.debug("bfGids:", bfGids || "undefined");
   } else {
-    logger.debug(
-      `First result metadata: ${JSON.stringify(results[0].metadata)}`,
-    );
+    logger.debug("First result metadata:", results[0].metadata);
   }
 
   return results;
@@ -301,10 +298,8 @@ export async function bfQueryItems<
 
   logger.debug(`Query results count: ${results.length}`);
   if (results.length > 0) {
-    logger.debug(
-      `First result metadata: ${JSON.stringify(results[0].metadata)}`,
-    );
-    logger.debug(`First result props: ${JSON.stringify(results[0].props)}`);
+    logger.debug("First result metadata:", results[0].metadata);
+    logger.debug("First result props:", results[0].props);
   } else {
     logger.debug(`No results found for query`);
   }

--- a/packages/bfDb/coreModels/BfNode.ts
+++ b/packages/bfDb/coreModels/BfNode.ts
@@ -208,9 +208,9 @@ export class BfNode<
     );
     logger.debug(
       `Edge query metadataQuery:`,
-      JSON.stringify(metadataQuery, null, 2),
+      metadataQuery,
     );
-    logger.debug(`Edge query propsQuery:`, JSON.stringify(propsQuery, null, 2));
+    logger.debug(`Edge query propsQuery:`, propsQuery);
     logger.debug(
       `Related edge class: ${this.relatedEdge}, derived edge name: ${relatedEdgeName}`,
     );
@@ -226,7 +226,7 @@ export class BfNode<
       );
       logger.debug(
         `All ${relatedEdgeName} edges in system:`,
-        JSON.stringify(createEdgeLog.slice(0, 5), null, 2),
+        createEdgeLog.slice(0, 5),
       );
     } catch (error) {
       logger.error(`Error looking up all edges:`, error);
@@ -262,7 +262,7 @@ export class BfNode<
       if (allEdgesFromSource.length > 0) {
         logger.debug(
           `Edge exists with source ID but not with props filter. First edge:`,
-          JSON.stringify(allEdgesFromSource[0], null, 2),
+          allEdgesFromSource[0],
         );
       }
 


### PR DESCRIPTION

## Summary
- Updated logger.debug calls to use direct object notation instead of JSON.stringify
- Fixed logging approach in bfDb.ts and BfNode.ts to avoid issues with BigInt serialization
- Made logging statements more readable and maintainable
- This follows best practices described in AGENT.md for handling object logging

## Test Plan
- Verified through precommit process
- Logs will now properly handle objects containing BigInt values
- Logging remains clear and readable for debugging purposes
