### PR TITLE
switch to neon as default driver

### DIFF
--- a/packages/bfDb/bfDbBackend.ts
+++ b/packages/bfDb/bfDbBackend.ts
@@ -48,7 +48,7 @@ export async function getBackend(): Promise<DatabaseBackend> {
     const forceBackend = getConfigurationVariable("FORCE_DB_BACKEND");
     const backendType = forceBackend ||
       (databaseUrl
-        ? getConfigurationVariable("DATABASE_BACKEND") ?? "pg"
+        ? getConfigurationVariable("DATABASE_BACKEND") ?? "neon"
         : "sqlite");
 
     logger.debug(`Creating database backend of type: ${backendType}`);


### PR DESCRIPTION

Summary:

Note: We should use https://jsr.io/@y0/postgres instead of pg probably.

Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/content-foundry/content-foundry/pull/351).
* #352
* __->__ #351